### PR TITLE
Make Candidates Page Random

### DIFF
--- a/_campaign-2019/andrey-akinshin.md
+++ b/_campaign-2019/andrey-akinshin.md
@@ -1,6 +1,7 @@
 ---
 title: Andrey Akinshin
 layout: default
+image: https://avatars3.githubusercontent.com/u/2259237?s=460&v=4
 ---
 
 # .NET Foundation Campaign: Andrey Akinshin

--- a/_campaign-2019/dave-glick.md
+++ b/_campaign-2019/dave-glick.md
@@ -1,6 +1,7 @@
 ---
 title: Dave Glick
 layout: default
+image: https://user-images.githubusercontent.com/1020407/53698333-3a655e80-3da9-11e9-931e-39ae72bf1104.jpg
 ---
 
 # .NET Foundation Campaign: Dave Glick

--- a/_campaign-2019/ginny-caughey.md
+++ b/_campaign-2019/ginny-caughey.md
@@ -1,6 +1,7 @@
 ---
 title: Ginny Caughey
 layout: default
+image: https://user-images.githubusercontent.com/6218283/53746947-38b29e00-3e70-11e9-982a-a0ddb0a9134b.jpg
 ---
 
 # .NET Foundation Campaign: Ginny Caughey

--- a/_campaign-2019/joseph-guadagno.md
+++ b/_campaign-2019/joseph-guadagno.md
@@ -1,6 +1,7 @@
 ---
 title: Joseph Guadagno
 layout: default
+image: https://avatars3.githubusercontent.com/u/3209610?s=250
 ---
 
 # .NET Foundation Campaign: Joseph Guadagno

--- a/_campaign-2019/marc-bruins.md
+++ b/_campaign-2019/marc-bruins.md
@@ -1,6 +1,7 @@
 ---
 title: Marc Bruins
 layout: default
+image: https://avatars3.githubusercontent.com/u/676025?s=200&u=d27539adff79207311f2090aff5baae13e663ec5&v=4
 ---
 
 # .NET Foundation Campaign: Marc Bruins

--- a/_campaign-2019/mattias-karlsson.md
+++ b/_campaign-2019/mattias-karlsson.md
@@ -1,6 +1,7 @@
 ---
 title: Mattias Karlsson
 layout: default
+image: https://user-images.githubusercontent.com/1647294/53631166-3521db80-3c12-11e9-8946-01c0c4da2d61.png
 ---
 
 # .NET Foundation Campaign: Mattias Karlsson

--- a/_campaign-2019/morten-nielsen.md
+++ b/_campaign-2019/morten-nielsen.md
@@ -1,6 +1,7 @@
 ---
 title: Morten Nielsen
 layout: default
+image: https://user-images.githubusercontent.com/1378165/53655225-71e6d600-3c04-11e9-89b9-69ce1261e53b.png
 ---
 
 # .NET Foundation Campaign: Morten Nielsen

--- a/_campaign-2019/oren-novotny.md
+++ b/_campaign-2019/oren-novotny.md
@@ -1,6 +1,7 @@
 ---
 title: Oren Novotny
 layout: default
+image: https://dnfwebsitewusproduction.blob.core.windows.net/media/Default/Images/oren-novotny.jpg
 ---
 
 # .NET Foundation Campaign: Oren Novotny

--- a/_campaign-2019/pratik-khandelwal.md
+++ b/_campaign-2019/pratik-khandelwal.md
@@ -1,6 +1,7 @@
 ---
 title: Pratik Khandelwal
 layout: default
+image: https://user-images.githubusercontent.com/12965931/54035164-bc58eb80-41de-11e9-9faf-e717eba0165a.jpg
 ---
 
 # .NET Foundation Campaign: Pratik Khandelwal

--- a/_campaign-2019/robert-mclaws.md
+++ b/_campaign-2019/robert-mclaws.md
@@ -1,6 +1,7 @@
 ---
 title: Robert McLaws
 layout: default
+image: https://user-images.githubusercontent.com/1657085/53609747-504f0580-3b96-11e9-979d-0727bcc63f42.png
 ---
 
 <div align="center">

--- a/_campaign-2019/shaun-walker.md
+++ b/_campaign-2019/shaun-walker.md
@@ -1,6 +1,7 @@
 ---
 title: Shaun Walker
 layout: default
+image: https://www.siliqon.com/portals/0/shaun%20walker.png
 ---
 
 # .NET Foundation Campaign: Shaun Walker

--- a/_campaign-2019/spencer-schneidenbach.md
+++ b/_campaign-2019/spencer-schneidenbach.md
@@ -1,6 +1,7 @@
 ---
 title: Spencer Schneidenbach
 layout: default
+image: https://avatars1.githubusercontent.com/u/3771777?s=200&v=4
 ---
 
 # .NET Foundation Campaign: Spencer Schneidenbach

--- a/_campaign-2019/steve-gordon.md
+++ b/_campaign-2019/steve-gordon.md
@@ -1,6 +1,7 @@
 ---
 title: Steve Gordon
 layout: default
+image: https://user-images.githubusercontent.com/3669103/53630658-7dd49700-3c08-11e9-8329-d5d6f27264c2.png
 ---
 
 # .NET Foundation Campaign: Steve Gordon

--- a/_campaign-2019/toni-solarin-sodara.md
+++ b/_campaign-2019/toni-solarin-sodara.md
@@ -1,6 +1,7 @@
 ---
 title: Toni Solarin-Sodara
 layout: default
+image: https://avatars.githubusercontent.com/tonerdo?size=220
 ---
 
 # .NET Foundation Campaign: Toni Solarin-Sodara

--- a/candidates.md
+++ b/candidates.md
@@ -10,7 +10,31 @@ Hey, we just launched the election and are waiting for our first election statem
 {% else %}
 ### Here are the campaign statements for our candidates.
 Interested in joining the race? [Here's how to get started](/campaign).
+
+<section class="card-container">
   {% for candidate in site.campaign-2019 %}
-  * [{{ candidate.title }}]({{ candidate.url }})
+    <article class="card">
+        <header class="card__title">
+            <h3>{{ candidate.title }}</h3>
+        </header>
+        <figure class="card__thumbnail">
+          {% if candidate.image %}
+            <img src="{{ candidate.image }}">
+          {% else %}
+            <img src="/img/dot_bot.png">
+          {% endif %}
+        </figure>
+        <a href="{{ candidate.url }}" class="card__button">Learn More</a>
+    </article>
   {% endfor %}
+</section>
+
 {% endif %}
+
+<script type="text/javascript">
+// https://stackoverflow.com/questions/7070054/javascript-shuffle-html-list-element-order
+var ul = document.querySelector('section.card-container');
+for (var i = ul.children.length; i >= 0; i--) {
+    ul.appendChild(ul.children[Math.random() * i | 0]);
+}
+</script>

--- a/css/home.css
+++ b/css/home.css
@@ -108,3 +108,49 @@
     width: 100%;
     height: 100%;
     background-color: rgba(104, 33, 122, 0.2); }
+/*
+ * adapted from
+ * https://bryanlrobinson.com/blog/2017/07/26/howto-css-grid-layout-to-make-a-simple-fluid-card-grid/
+ */
+.card-container {
+      display: grid;
+      padding: 1rem;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      grid-gap: 1rem;
+  }
+.card {
+    display: grid;
+}
+.card .button {
+    align-self: end;
+}
+.card {
+  box-shadow: 0px 1px 5px #555;
+  background-color: white;
+}
+.card__title {
+  font-size: 2rem;
+  padding: .5rem;
+  text-align: center;
+}
+.card__description {
+  padding: .5rem;
+  line-height: 1.6em;
+}
+.card__button {
+  display: block;
+  background-color: #68217a;
+  padding: 10px 20px;
+  color: white;
+  text-decoration: none;
+  text-align: center;
+  transition: .3s ease-out;
+}
+
+.card__thumbnail {
+  text-align: center;
+}
+
+.card__thumbnail img {
+  height: 128px;
+}

--- a/example.md
+++ b/example.md
@@ -1,6 +1,7 @@
 ---
 title: Example
 layout: default
+image: /img/dot_bot.png
 ---
 
 # .NET Foundation Campaign: [Your Name Here]


### PR DESCRIPTION
This PR includes an enhancement to the candidate's page where
an individuals photo is displayed in a grid. Additionally, we
are randomizing the candidate page (using JavaScript) to help
folks get a much more fair opportunity to be seen by .NET Foundation
voting members.

The screenshot is a random result for loading the page.

![127 0 0 1_4000_candidates](https://user-images.githubusercontent.com/228256/54092689-737f6f00-4365-11e9-8dcf-e7018969879d.png)