### PR TITLE
Fix typo on auto-labeling

### DIFF
--- a/.github/ISSUE_TEMPLATE/electionquestion.md
+++ b/.github/ISSUE_TEMPLATE/electionquestion.md
@@ -1,7 +1,7 @@
 ---
 name: Election Question
 about: Do you have a question for the Board of Director election candidates? Submit it here!
-labels: candidate-questions
+labels: candidate-question
 ---
 
 <!-- We're happy that you're willing to engage with the candidates! Thanks for taking the time to submit a candidate. Please see the directions below. -->


### PR DESCRIPTION
`questions` vs `question` (I copied/pasted from a previous suggestion without double-checking.)